### PR TITLE
更新loadCountries的正则表达式以适配最新的丁香园数据格式

### DIFF
--- a/scripts/build-origin.js
+++ b/scripts/build-origin.js
@@ -16,7 +16,7 @@ const getCitiesByProvince = (name) => {
 
 const loadCountries = async data => {
   const countries = data
-    .match(/window.getListByCountryTypeService2 = (.*?)}catch/)[1]
+    .match(/window.getListByCountryTypeService2true = (.*?)}catch/)[1]
   fs.writeFileSync('./src/data/countries.json', countries)
 }
 


### PR DESCRIPTION
丁香园的页面数据格式已经改变了，直接运行build-origin.js会报错